### PR TITLE
Fixed the bug where users were no longer able to move chats to workspaces, caused by the migration to MudBlazor 7.x.x

### DIFF
--- a/app/MindWork AI Studio/Components/CommonDialogs/WorkspaceSelectionDialog.razor
+++ b/app/MindWork AI Studio/Components/CommonDialogs/WorkspaceSelectionDialog.razor
@@ -1,7 +1,7 @@
 <MudDialog>
     <DialogContent>
         <MudText Typo="Typo.body1">@this.Message</MudText>
-        <MudList @bind-SelectedValue="@this.selectedWorkspace">
+        <MudList T="Guid" @bind-SelectedValue="@this.selectedWorkspace">
             @foreach (var (workspaceName, workspaceId) in this.workspaces)
             {
                 <MudListItem Text="@workspaceName" Icon="@Icons.Material.Filled.Description" Value="@workspaceId" />

--- a/app/MindWork AI Studio/Components/CommonDialogs/WorkspaceSelectionDialog.razor.cs
+++ b/app/MindWork AI Studio/Components/CommonDialogs/WorkspaceSelectionDialog.razor.cs
@@ -21,7 +21,7 @@ public partial class WorkspaceSelectionDialog : ComponentBase
     public string ConfirmText { get; set; } = "OK";
     
     private readonly Dictionary<string, Guid> workspaces = new();
-    private object? selectedWorkspace;
+    private Guid selectedWorkspace;
 
     #region Overrides of ComponentBase
 
@@ -56,5 +56,5 @@ public partial class WorkspaceSelectionDialog : ComponentBase
 
     private void Cancel() => this.MudDialog.Cancel();
     
-    private void Confirm() => this.MudDialog.Close(DialogResult.Ok(this.selectedWorkspace is Guid workspaceId ? workspaceId : default));
+    private void Confirm() => this.MudDialog.Close(DialogResult.Ok(this.selectedWorkspace));
 }

--- a/app/MindWork AI Studio/wwwroot/changelog/v0.8.5.md
+++ b/app/MindWork AI Studio/wwwroot/changelog/v0.8.5.md
@@ -7,6 +7,7 @@
 - Improved switches: when an option is enabled, the switch is using a different color
 - Fixed the applying of spellchecking settings to the single-line dialog
 - Fixed the bug where users cannot delete a self-hosted provider when an API token was never entered
+- Fixed the bug where users were no longer able to move chats to workspaces, caused by the migration to MudBlazor 7.x.x
 - Restructured the layout of the settings page 
 - Refactored the settings data model
 - Upgraded to Rust 1.80.0


### PR DESCRIPTION
Fixed the bug where users were no longer able to move chats to workspaces, caused by the migration to MudBlazor 7.x.x