### PR TITLE
**Update .gitignore and improve build.nu script**:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,5 +147,4 @@ orleans.codegen.cs
 **/.idea/**/dynamic.xml
 **/.idea/**/uiDesigner.xml
 **/.idea/**/dbnavigator.xml
-/.vs
-/app/.vs
+**/.vs

--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,5 @@ orleans.codegen.cs
 **/.idea/**/dynamic.xml
 **/.idea/**/uiDesigner.xml
 **/.idea/**/dbnavigator.xml
+/.vs
+/app/.vs

--- a/app/MindWork AI Studio/build.nu
+++ b/app/MindWork AI Studio/build.nu
@@ -196,7 +196,7 @@ def update_dotnet_version []: nothing -> nothing {
     mut dotnet_sdk_version = $meta_lines.3
     mut dotnet_version = $meta_lines.4
     
-    let dotnet_data = (^dotnet --info) | collect | parse --regex '(?ms).?NET SDK:\s+Version:\s+(?P<sdkVersion>[0-9.]+).+Commit:\s+(?P<sdkCommit>[a-zA-Z0-9]+).+Host:\s+Version:\s+(?P<hostVersion>[0-9.]+).+Commit:\s+(?P<hostCommit>[a-zA-Z0-9]+)'
+    let dotnet_data = (^dotnet --info) | collect | parse --regex '(?ms).?(NET\s+SDK|SDK\s+\.NET)\s*:\s+Version:\s+(?P<sdkVersion>[0-9.]+).+Commit:\s+(?P<sdkCommit>[a-zA-Z0-9]+).+Host:\s+Version:\s+(?P<hostVersion>[0-9.]+).+Commit:\s+(?P<hostCommit>[a-zA-Z0-9]+)'
     let sdk_version = $dotnet_data.sdkVersion.0
     let host_version = $dotnet_data.hostVersion.0
     let sdkCommit = $dotnet_data.sdkCommit.0


### PR DESCRIPTION
- Added patterns to ignore Visual Studio's `.vs` directories to keep the repository clean and reduce unnecessary files tracked by Git.
- Fixed an issue with the `nu build.nu publish` command under Windows 11, Visual Studio 2022, and .NET SDK 9.
- Updated the regular expression in the `update_dotnet_version` function to correctly parse the version information from the `dotnet --info` output.

**Example Output of `dotnet --info`:**
```plaintext
.NET SDK:
 Version:           9.0.101
 Commit:            eedb237549
 Workload version:  9.0.100-manifests.4a280210
 MSBuild version:   17.12.12+1cce77968

[...]

Host:
  Version:      9.0.0
  Architecture: x64
  Commit:       9d5a6a9aa4
```