### PR TITLE
Added a new Panel in the About section regarding the Github Repo of AI Studio/ERI/Roadmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,7 @@ orleans.codegen.cs
 
 # Generated files
 **/.idea/**/contentModel.xml
+packages.lock.json
 
 # Sensitive or high-churn files
 **/.idea/**/dataSources/

--- a/.gitignore
+++ b/.gitignore
@@ -138,7 +138,7 @@ orleans.codegen.cs
 
 # Generated files
 **/.idea/**/contentModel.xml
-packages.lock.json
+/app/MindWork AI Studio/packages.lock.json
 
 # Sensitive or high-churn files
 **/.idea/**/dataSources/

--- a/.gitignore
+++ b/.gitignore
@@ -138,7 +138,6 @@ orleans.codegen.cs
 
 # Generated files
 **/.idea/**/contentModel.xml
-/app/MindWork AI Studio/packages.lock.json
 
 # Sensitive or high-churn files
 **/.idea/**/dataSources/

--- a/app/MindWork AI Studio/Pages/About.razor
+++ b/app/MindWork AI Studio/Pages/About.razor
@@ -23,20 +23,13 @@
                 </MudButton>
             </ExpansionPanel>
 
-            <ExpansionPanel HeaderIcon="@Icons.Material.Filled.Source" HeaderText="Development">
-                <MudText>
-                    <MudIcon Icon="@Icons.Custom.Brands.GitHub" Size="Size.Medium" Class="mr-2" Style="vertical-align: text-bottom;"/>
-                    You can find the code for AI Studio on GitHub:
-                    <MudLink Href="https://github.com/MindWorkAI/AI-Studio" Target="_blank" Color="Color.Primary">AI Studio</MudLink>
-                </MudText>
-
-                <MudDivider Class="my-2" />
-
-                <MudText>
-                    <MudIcon Icon="@Icons.Material.Filled.DeveloperBoard" Size="Size.Medium" Class="mr-2" Style="vertical-align: text-bottom;"/>
-                    Interested in participating in the development? Check our:
-                    <MudLink Href="https://github.com/orgs/MindWorkAI/projects/2" Target="_blank" Color="Color.Primary">Development Roadmap</MudLink>
-                </MudText>
+            <ExpansionPanel HeaderIcon="@Icons.Custom.Brands.GitHub" HeaderText="Development">
+                <MudList T="string" Class="mb-1">
+                    <MudListItem T="string" Icon="@Icons.Material.Outlined.Home" Target="_blank" Href="http://mindworkai.org/">Visit our official homepage to learn about MindWork AI's mission and vision!</MudListItem>
+                    <MudListItem T="string" Icon="@Icons.Custom.Brands.GitHub" Target="_blank" Href="https://github.com/MindWorkAI/AI-Studio">Explore the complete source code for AI Studio on GitHub — contributions welcome!</MudListItem>
+                    <MudListItem T="string" Icon="@Icons.Material.Outlined.DeveloperBoard" Target="_blank" Href="https://github.com/orgs/MindWorkAI/projects/2">See our planned features in the project's roadmap — join the development team and help shape the future!</MudListItem>
+                    <MudListItem T="string" Icon="@Icons.Material.Outlined.PrivateConnectivity" Target="_blank" Href="https://github.com/MindWorkAI/ERI">Securely interact with your company's data using AI Studio and our External Retrieval Interface (ERI)!</MudListItem>
+                </MudList>
             </ExpansionPanel>
             
             <ExpansionPanel HeaderIcon="@Icons.Material.Filled.EventNote" HeaderText="Changelog">

--- a/app/MindWork AI Studio/Pages/About.razor
+++ b/app/MindWork AI Studio/Pages/About.razor
@@ -22,6 +22,22 @@
                     Check for updates
                 </MudButton>
             </ExpansionPanel>
+
+            <ExpansionPanel HeaderIcon="@Icons.Material.Filled.Source" HeaderText="Development">
+                <MudText>
+                    <MudIcon Icon="@Icons.Custom.Brands.GitHub" Size="Size.Medium" Class="mr-2" Style="vertical-align: text-bottom;"/>
+                    You can find the code for AI Studio on GitHub:
+                    <MudLink Href="https://github.com/MindWorkAI/AI-Studio" Target="_blank" Color="Color.Primary">AI Studio</MudLink>
+                </MudText>
+
+                <MudDivider Class="my-2" />
+
+                <MudText>
+                    <MudIcon Icon="@Icons.Material.Filled.DeveloperBoard" Size="Size.Medium" Class="mr-2" Style="vertical-align: text-bottom;"/>
+                    Interested in participating in the development? Check our:
+                    <MudLink Href="https://github.com/orgs/MindWorkAI/projects/2" Target="_blank" Color="Color.Primary">Development Roadmap</MudLink>
+                </MudText>
+            </ExpansionPanel>
             
             <ExpansionPanel HeaderIcon="@Icons.Material.Filled.EventNote" HeaderText="Changelog">
                 <Changelog/>

--- a/app/MindWork AI Studio/Pages/About.razor
+++ b/app/MindWork AI Studio/Pages/About.razor
@@ -34,11 +34,11 @@
                     <MudListItem T="string" Icon="@Icons.Material.Outlined.PrivateConnectivity" Target="_blank" Href="https://github.com/MindWorkAI/ERI">
                         Connect AI Studio to your organization's data with our External Retrieval Interface (ERI).
                     </MudListItem>
-                    <MudListItem T="string" Icon="@Icons.Material.Outlined.Timeline" Target="_blank" Href="https://github.com/orgs/MindWorkAI/projects/2">
+                    <MudListItem T="string" Icon="@Icons.Material.Outlined.Timeline" Target="_blank" Href="https://github.com/orgs/MindWorkAI/projects/2/views/3">
                         View our project roadmap and help shape AI Studio's future development.
                     </MudListItem>
                     <MudListItem T="string" Icon="@Icons.Material.Outlined.BugReport" Target="_blank" Href="https://github.com/MindWorkAI/AI-Studio/issues">
-                        Experiencing issues? Report bugs so we can provide assistance.
+                        Did you find a bug or are you experiencing issues? Report your concern here.
                     </MudListItem>
                     <MudListItem T="string" Icon="@Icons.Material.Outlined.Lightbulb" Target="_blank" Href="https://github.com/MindWorkAI/Planning/issues">
                         Have feature ideas? Submit suggestions for future AI Studio enhancements.

--- a/app/MindWork AI Studio/Pages/About.razor
+++ b/app/MindWork AI Studio/Pages/About.razor
@@ -23,12 +23,26 @@
                 </MudButton>
             </ExpansionPanel>
 
-            <ExpansionPanel HeaderIcon="@Icons.Custom.Brands.GitHub" HeaderText="Development">
+            <ExpansionPanel HeaderIcon="@Icons.Custom.Brands.GitHub" HeaderText="Community & Code">
                 <MudList T="string" Class="mb-1">
-                    <MudListItem T="string" Icon="@Icons.Material.Outlined.Home" Target="_blank" Href="http://mindworkai.org/">Visit our official homepage to learn about MindWork AI's mission and vision!</MudListItem>
-                    <MudListItem T="string" Icon="@Icons.Custom.Brands.GitHub" Target="_blank" Href="https://github.com/MindWorkAI/AI-Studio">Explore the complete source code for AI Studio on GitHub — contributions welcome!</MudListItem>
-                    <MudListItem T="string" Icon="@Icons.Material.Outlined.DeveloperBoard" Target="_blank" Href="https://github.com/orgs/MindWorkAI/projects/2">See our planned features in the project's roadmap — join the development team and help shape the future!</MudListItem>
-                    <MudListItem T="string" Icon="@Icons.Material.Outlined.PrivateConnectivity" Target="_blank" Href="https://github.com/MindWorkAI/ERI">Securely interact with your company's data using AI Studio and our External Retrieval Interface (ERI)!</MudListItem>
+                    <MudListItem T="string" Icon="@Icons.Material.Outlined.Home" Target="_blank" Href="http://mindworkai.org/">
+                        Discover MindWork AI's mission and vision on our official homepage.
+                    </MudListItem>
+                    <MudListItem T="string" Icon="@Icons.Custom.Brands.GitHub" Target="_blank" Href="https://github.com/MindWorkAI/AI-Studio">
+                        Browse AI Studio's source code on GitHub — we welcome your contributions.
+                    </MudListItem>
+                    <MudListItem T="string" Icon="@Icons.Material.Outlined.PrivateConnectivity" Target="_blank" Href="https://github.com/MindWorkAI/ERI">
+                        Connect AI Studio to your organization's data with our External Retrieval Interface (ERI).
+                    </MudListItem>
+                    <MudListItem T="string" Icon="@Icons.Material.Outlined.Timeline" Target="_blank" Href="https://github.com/orgs/MindWorkAI/projects/2">
+                        View our project roadmap and help shape AI Studio's future development.
+                    </MudListItem>
+                    <MudListItem T="string" Icon="@Icons.Material.Outlined.BugReport" Target="_blank" Href="https://github.com/MindWorkAI/AI-Studio/issues">
+                        Experiencing issues? Report bugs so we can provide assistance.
+                    </MudListItem>
+                    <MudListItem T="string" Icon="@Icons.Material.Outlined.Lightbulb" Target="_blank" Href="https://github.com/MindWorkAI/Planning/issues">
+                        Have feature ideas? Submit suggestions for future AI Studio enhancements.
+                    </MudListItem>
                 </MudList>
             </ExpansionPanel>
             

--- a/app/MindWork AI Studio/wwwroot/changelog/v0.9.32.md
+++ b/app/MindWork AI Studio/wwwroot/changelog/v0.9.32.md
@@ -1,0 +1,2 @@
+﻿# v0.9.32, build 207 (2025-03-xx xx:xx UTC)
+- Added links to the GitHub repo of AI Studio, ERI and the Development Roadmap to the About page

--- a/app/MindWork AI Studio/wwwroot/changelog/v0.9.32.md
+++ b/app/MindWork AI Studio/wwwroot/changelog/v0.9.32.md
@@ -1,2 +1,2 @@
 ﻿# v0.9.32, build 207 (2025-03-xx xx:xx UTC)
-- Added links to the GitHub repo of AI Studio, ERI and the Development Roadmap to the About page
+- Added the Community & Code section to the About page. It includes links to the GitHub repositories and the project homepage. 


### PR DESCRIPTION
Added a link to the GitHub repo, the development roadmap, ERI and the project website, as proposed in MindWorkAI/Planning#4. Furthermore, excluded a file from version tracking that is automatically created during building.