### PR TITLE
Bugs in & related to the web content reader

### DIFF
--- a/app/MindWork AI Studio/Assistants/LegalCheck/AssistantLegalCheck.razor
+++ b/app/MindWork AI Studio/Assistants/LegalCheck/AssistantLegalCheck.razor
@@ -3,7 +3,7 @@
 
 @if (!this.SettingsManager.ConfigurationData.LegalCheck.HideWebContentReader)
 {
-    <ReadWebContent @bind-Content="@this.inputLegalDocument" ProviderSettings="@this.providerSettings" @bind-AgentIsRunning="@this.isAgentRunning" Preselect="@(this.SettingsManager.ConfigurationData.LegalCheck.PreselectOptions && this.SettingsManager.ConfigurationData.LegalCheck.PreselectWebContentReader)" PreselectContentCleanerAgent="@(this.SettingsManager.ConfigurationData.LegalCheck.PreselectOptions && this.SettingsManager.ConfigurationData.LegalCheck.PreselectContentCleanerAgent)"/>
+    <ReadWebContent @bind-Content="@this.inputLegalDocument" ProviderSettings="@this.providerSettings" @bind-AgentIsRunning="@this.isAgentRunning" @bind-Preselect="@this.showWebContentReader" @bind-PreselectContentCleanerAgent="@this.useContentCleanerAgent"/>
 }
 
 <ReadFileContent @bind-FileContent="@this.inputLegalDocument"/>

--- a/app/MindWork AI Studio/Assistants/LegalCheck/AssistantLegalCheck.razor.cs
+++ b/app/MindWork AI Studio/Assistants/LegalCheck/AssistantLegalCheck.razor.cs
@@ -37,11 +37,27 @@ public partial class AssistantLegalCheck : AssistantBaseCore<SettingsDialogLegal
     {
         this.inputLegalDocument = string.Empty;
         this.inputQuestions = string.Empty;
-        this.MightPreselectValues();
+        if (!this.MightPreselectValues())
+        {
+            this.showWebContentReader = false;
+            this.useContentCleanerAgent = false;
+        }
     }
-    
-    protected override bool MightPreselectValues() => false;
 
+    protected override bool MightPreselectValues()
+    {
+        if (this.SettingsManager.ConfigurationData.LegalCheck.PreselectOptions)
+        {
+            this.showWebContentReader = this.SettingsManager.ConfigurationData.LegalCheck.PreselectWebContentReader;
+            this.useContentCleanerAgent = this.SettingsManager.ConfigurationData.LegalCheck.PreselectContentCleanerAgent;
+            return true;
+        }
+        
+        return false;
+    }
+
+    private bool showWebContentReader;
+    private bool useContentCleanerAgent;
     private bool isAgentRunning;
     private string inputLegalDocument = string.Empty;
     private string inputQuestions = string.Empty;

--- a/app/MindWork AI Studio/Assistants/TextSummarizer/AssistantTextSummarizer.razor
+++ b/app/MindWork AI Studio/Assistants/TextSummarizer/AssistantTextSummarizer.razor
@@ -3,7 +3,7 @@
 
 @if (!this.SettingsManager.ConfigurationData.TextSummarizer.HideWebContentReader)
 {
-    <ReadWebContent @bind-Content="@this.inputText" ProviderSettings="@this.providerSettings" @bind-AgentIsRunning="@this.isAgentRunning" Preselect="@(this.SettingsManager.ConfigurationData.TextSummarizer.PreselectOptions && this.SettingsManager.ConfigurationData.TextSummarizer.PreselectWebContentReader)" PreselectContentCleanerAgent="@(this.SettingsManager.ConfigurationData.TextSummarizer.PreselectOptions && this.SettingsManager.ConfigurationData.TextSummarizer.PreselectContentCleanerAgent)"/>
+    <ReadWebContent @bind-Content="@this.inputText" ProviderSettings="@this.providerSettings" @bind-AgentIsRunning="@this.isAgentRunning" @bind-Preselect="@this.showWebContentReader" @bind-PreselectContentCleanerAgent="@this.useContentCleanerAgent"/>
 }
 
 <ReadFileContent @bind-FileContent="@this.inputText"/>

--- a/app/MindWork AI Studio/Assistants/TextSummarizer/AssistantTextSummarizer.razor.cs
+++ b/app/MindWork AI Studio/Assistants/TextSummarizer/AssistantTextSummarizer.razor.cs
@@ -40,6 +40,8 @@ public partial class AssistantTextSummarizer : AssistantBaseCore<SettingsDialogT
         this.inputText = string.Empty;
         if(!this.MightPreselectValues())
         {
+            this.showWebContentReader = false;
+            this.useContentCleanerAgent = false;
             this.selectedTargetLanguage = CommonLanguages.AS_IS;
             this.customTargetLanguage = string.Empty;
             this.selectedComplexity = Complexity.NO_CHANGE;
@@ -52,6 +54,8 @@ public partial class AssistantTextSummarizer : AssistantBaseCore<SettingsDialogT
     {
         if (this.SettingsManager.ConfigurationData.TextSummarizer.PreselectOptions)
         {
+            this.showWebContentReader = this.SettingsManager.ConfigurationData.TextSummarizer.PreselectWebContentReader;
+            this.useContentCleanerAgent = this.SettingsManager.ConfigurationData.TextSummarizer.PreselectContentCleanerAgent;
             this.selectedTargetLanguage = this.SettingsManager.ConfigurationData.TextSummarizer.PreselectedTargetLanguage;
             this.customTargetLanguage = this.SettingsManager.ConfigurationData.TextSummarizer.PreselectedOtherLanguage;
             this.selectedComplexity = this.SettingsManager.ConfigurationData.TextSummarizer.PreselectedComplexity;
@@ -63,6 +67,8 @@ public partial class AssistantTextSummarizer : AssistantBaseCore<SettingsDialogT
         return false;
     }
     
+    private bool showWebContentReader;
+    private bool useContentCleanerAgent;
     private string inputText = string.Empty;
     private bool isAgentRunning;
     private CommonLanguages selectedTargetLanguage;

--- a/app/MindWork AI Studio/Assistants/Translation/AssistantTranslation.razor
+++ b/app/MindWork AI Studio/Assistants/Translation/AssistantTranslation.razor
@@ -3,7 +3,7 @@
 
 @if (!this.SettingsManager.ConfigurationData.Translation.HideWebContentReader)
 {
-    <ReadWebContent @bind-Content="@this.inputText" ProviderSettings="@this.providerSettings" @bind-AgentIsRunning="@this.isAgentRunning" Preselect="@(this.SettingsManager.ConfigurationData.Translation.PreselectOptions && this.SettingsManager.ConfigurationData.Translation.PreselectWebContentReader)" PreselectContentCleanerAgent="@(this.SettingsManager.ConfigurationData.Translation.PreselectOptions && this.SettingsManager.ConfigurationData.Translation.PreselectContentCleanerAgent)"/>
+    <ReadWebContent @bind-Content="@this.inputText" ProviderSettings="@this.providerSettings" @bind-AgentIsRunning="@this.isAgentRunning" @bind-Preselect="@this.showWebContentReader" @bind-PreselectContentCleanerAgent="@this.useContentCleanerAgent"/>
 }
 
 <ReadFileContent @bind-FileContent="@this.inputText"/>

--- a/app/MindWork AI Studio/Assistants/Translation/AssistantTranslation.razor.cs
+++ b/app/MindWork AI Studio/Assistants/Translation/AssistantTranslation.razor.cs
@@ -40,6 +40,8 @@ public partial class AssistantTranslation : AssistantBaseCore<SettingsDialogTran
         this.inputTextLastTranslation = string.Empty;
         if (!this.MightPreselectValues())
         {
+            this.showWebContentReader = false;
+            this.useContentCleanerAgent = false;
             this.liveTranslation = false;
             this.selectedTargetLanguage = CommonLanguages.AS_IS;
             this.customTargetLanguage = string.Empty;
@@ -50,6 +52,8 @@ public partial class AssistantTranslation : AssistantBaseCore<SettingsDialogTran
     {
         if (this.SettingsManager.ConfigurationData.Translation.PreselectOptions)
         {
+            this.showWebContentReader = this.SettingsManager.ConfigurationData.Translation.PreselectWebContentReader;
+            this.useContentCleanerAgent = this.SettingsManager.ConfigurationData.Translation.PreselectContentCleanerAgent;
             this.liveTranslation = this.SettingsManager.ConfigurationData.Translation.PreselectLiveTranslation;
             this.selectedTargetLanguage = this.SettingsManager.ConfigurationData.Translation.PreselectedTargetLanguage;
             this.customTargetLanguage = this.SettingsManager.ConfigurationData.Translation.PreselectOtherLanguage;
@@ -59,6 +63,8 @@ public partial class AssistantTranslation : AssistantBaseCore<SettingsDialogTran
         return false;
     }
     
+    private bool showWebContentReader;
+    private bool useContentCleanerAgent;
     private bool liveTranslation;
     private bool isAgentRunning;
     private string inputText = string.Empty;

--- a/app/MindWork AI Studio/Components/ReadWebContent.razor
+++ b/app/MindWork AI Studio/Components/ReadWebContent.razor
@@ -1,9 +1,9 @@
 @inherits MSGComponentBase
 <MudPaper Class="pa-3 mb-3 border-dashed border rounded-lg">
-    <MudTextSwitch Label="@T("Read content from web?")" Disabled="@this.AgentIsRunning" @bind-Value="@this.showWebContentReader" LabelOn="@T("Show web content options")" LabelOff="@T("Hide web content options")" />
-    @if (this.showWebContentReader)
+    <MudTextSwitch Label="@T("Read content from web?")" Disabled="@this.AgentIsRunning" Value="@this.Preselect" ValueChanged="@this.ShowWebContentReaderChanged" LabelOn="@T("Show web content options")" LabelOff="@T("Hide web content options")" />
+    @if (this.Preselect)
     {
-        <MudTextSwitch Label="@T("Cleanup content by using an LLM agent?")" @bind-Value="@this.useContentCleanerAgent" Validation="@this.ValidateProvider" Disabled="@this.AgentIsRunning" LabelOn="@T("The content is cleaned using an LLM agent: the main content is extracted, advertisements and other irrelevant things are attempted to be removed; relative links are attempted to be converted into absolute links so that they can be used.")" LabelOff="@T("No content cleaning")" />
+        <MudTextSwitch Label="@T("Cleanup content by using an LLM agent?")" Value="@this.PreselectContentCleanerAgent" ValueChanged="@this.UseContentCleanerAgentChanged" Validation="@this.ValidateProvider" Disabled="@this.AgentIsRunning" LabelOn="@T("The content is cleaned using an LLM agent: the main content is extracted, advertisements and other irrelevant things are attempted to be removed; relative links are attempted to be converted into absolute links so that they can be used.")" LabelOff="@T("No content cleaning")" />
         <MudStack Row="@true" AlignItems="@AlignItems.Baseline" Class="mb-3">
             <MudTextField T="string" Label="@T("URL from which to load the content")" @bind-Value="@this.providedURL" Validation="@this.ValidateURL" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Link" Placeholder="https://..." HelperText="@T("Loads the content from your URL. Does not work when the content is hidden behind a paywall.")" Variant="Variant.Outlined" Immediate="@true" Disabled="@this.AgentIsRunning"/>
             <MudButton Disabled="@(!this.IsReady || this.AgentIsRunning)" Variant="Variant.Filled" Size="Size.Large" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Download" OnClick="() => this.LoadFromWeb()">

--- a/app/MindWork AI Studio/Components/ReadWebContent.razor.cs
+++ b/app/MindWork AI Studio/Components/ReadWebContent.razor.cs
@@ -56,6 +56,7 @@ public partial class ReadWebContent : MSGComponentBase
             this.useContentCleanerAgent = true;
         
         this.ProviderSettings = this.SettingsManager.GetPreselectedProvider(Tools.Components.AGENT_TEXT_CONTENT_CLEANER, this.ProviderSettings.Id, true);
+        this.providerSettings = this.ProviderSettings;
         await base.OnInitializedAsync();
     }
 

--- a/app/MindWork AI Studio/Components/ReadWebContent.razor.cs
+++ b/app/MindWork AI Studio/Components/ReadWebContent.razor.cs
@@ -57,6 +57,8 @@ public partial class ReadWebContent : MSGComponentBase
         
         this.ProviderSettings = this.SettingsManager.GetPreselectedProvider(Tools.Components.AGENT_TEXT_CONTENT_CLEANER, this.ProviderSettings.Id, true);
         this.providerSettings = this.ProviderSettings;
+        this.ValidateProvider(this.useContentCleanerAgent);
+        
         await base.OnInitializedAsync();
     }
 
@@ -65,6 +67,7 @@ public partial class ReadWebContent : MSGComponentBase
         if (!this.SettingsManager.ConfigurationData.TextContentCleaner.PreselectAgentOptions)
             this.providerSettings = this.ProviderSettings;
         
+        this.ValidateProvider(this.useContentCleanerAgent);
         await base.OnParametersSetAsync();
     }
 

--- a/app/MindWork AI Studio/wwwroot/changelog/v0.9.51.md
+++ b/app/MindWork AI Studio/wwwroot/changelog/v0.9.51.md
@@ -13,3 +13,6 @@
 - Fixed a bug in various assistants where some text fields were not reset when resetting.
 - Fixed the input field header in the dialog for naming chats and workspaces.
 - Fixed a rare chat-related bug that could occur when a workspace was not created correctly. Thank you, Naomi, for reporting this issue.
+- Fixed a bug in the web content reader where a preconfigured LLM provider was not recognized, resulting in an error message.
+- Fixed another bug in the web content reader: the system incorrectly evaluated whether the content cleaning agent was preselected. Users had to first deactivate the agent and then reactivate it to make it work correctly.
+- Fixed a bug in the assistants for text summarization, translations, and legal check: the web content reader preferences were not being applied when resetting the assistant.


### PR DESCRIPTION
# Problem
The content cleaner had a bug where preselecting a provider in the agent caused the content cleaner to report that no llm provider has been preselected.

<img width="1079" height="354" alt="grafik" src="https://github.com/user-attachments/assets/136e7ace-97ef-462c-beda-6b002c18590d" />

<img width="1061" height="209" alt="grafik" src="https://github.com/user-attachments/assets/58aa5f85-7383-42a0-996b-58cd37a1dc10" />

# Solution
I think we forgot to initialize the parameter and I rectified this.
