### PR TITLE
Focus chat input field when it becomes enabled

### DIFF
--- a/app/MindWork AI Studio/Components/ChatComponent.razor.cs
+++ b/app/MindWork AI Studio/Components/ChatComponent.razor.cs
@@ -69,6 +69,9 @@ public partial class ChatComponent : MSGComponentBase, IAsyncDisposable
     private bool mustLoadChat;
     private LoadChat loadChat;
     private bool autoSaveEnabled;
+    private bool previousInputForbidden = true;
+    private Guid lastSeenChatId = Guid.Empty;
+    private AIStudio.Settings.Provider lastSeenProvider = AIStudio.Settings.Provider.NONE;
     private string currentWorkspaceName = string.Empty;
     private Guid currentWorkspaceId = Guid.Empty;
     private Guid currentChatThreadId = Guid.Empty;
@@ -287,12 +290,25 @@ public partial class ChatComponent : MSGComponentBase, IAsyncDisposable
                 this.StateHasChanged();
             }
         }
-        
+
+        var inputForbidden = this.IsInputForbidden();
+        if (!inputForbidden && this.previousInputForbidden)
+            await this.inputField.FocusAsync();
+
+        this.previousInputForbidden = inputForbidden;
         await base.OnAfterRenderAsync(firstRender);
     }
 
     protected override async Task OnParametersSetAsync()
     {
+        var incomingChatId = this.ChatThread?.ChatId ?? Guid.Empty;
+        if (incomingChatId != this.lastSeenChatId || this.Provider != this.lastSeenProvider)
+        {
+            this.lastSeenChatId = incomingChatId;
+            this.lastSeenProvider = this.Provider;
+            this.previousInputForbidden = true;
+        }
+
         await this.ApplyLoadedChatParameterAsync();
         await this.SyncForegroundChatAsync();
         await base.OnParametersSetAsync();
@@ -1124,7 +1140,10 @@ public partial class ChatComponent : MSGComponentBase, IAsyncDisposable
                 {
                     this.ChatThread = this.AIJobService.TryGetLiveChatThread(snapshot.SubjectId) ?? this.ChatThread;
                     if (!snapshot.IsActive)
+                    {
                         this.hasUnsavedChanges = false;
+                        this.previousInputForbidden = true;
+                    }
 
                     this.StateHasChanged();
                 }

--- a/app/MindWork AI Studio/wwwroot/changelog/v26.6.3.md
+++ b/app/MindWork AI Studio/wwwroot/changelog/v26.6.3.md
@@ -1,1 +1,2 @@
 # v26.6.3, build 243 (2026-06-xx xx:xx UTC)
+- Improved the chat experience by automatically focusing the message composer again when it becomes available. Thanks, Dominic Neuburg (`donework`), for the contribution.


### PR DESCRIPTION
## Summary

- Automatically focus the chat input field whenever it transitions
  from disabled to enabled
- This allows users to start typing immediately without an extra click

## When does the input field receive focus?

- On initial load when a provider is already preselected
- When the user selects or changes a provider
- After the AI finishes responding
- When switching between chats
- When starting a new chat

## Implementation

The focus logic is based on transition detection in `OnAfterRenderAsync`:
the input field receives focus whenever `IsInputForbidden()` transitions
from `true` to `false`. Three additional fields track the previous state
to detect transitions caused by chat switches and provider changes.