### PR TITLE
Fix single line breaks rendering as spaces in chat messages

### DIFF
--- a/app/MindWork AI Studio/Chat/ContentBlockComponent.razor
+++ b/app/MindWork AI Studio/Chat/ContentBlockComponent.razor
@@ -103,7 +103,7 @@
                                         var segmentContent = segment.GetContent(renderPlan.Source);
                                         if (segment.Type is MarkdownRenderSegmentType.MARKDOWN)
                                         {
-                                            <MudMarkdown @key="@segment.RenderKey" Value="@segmentContent" Props="Markdown.DefaultConfig" Styling="@this.MarkdownStyling" MarkdownPipeline="Markdown.SAFE_MARKDOWN_PIPELINE" />
+                                            <MudMarkdown @key="@segment.RenderKey" Value="@segmentContent" Props="Markdown.DefaultConfig" Styling="@this.MarkdownStyling" MarkdownPipeline="Markdown.CHAT_MARKDOWN_PIPELINE" />
                                         }
                                         else
                                         {

--- a/app/MindWork AI Studio/Tools/Markdown.cs
+++ b/app/MindWork AI Studio/Tools/Markdown.cs
@@ -10,6 +10,12 @@ public static class Markdown
         .DisableHtml()
         .Build();
 
+    public static readonly MarkdownPipeline CHAT_MARKDOWN_PIPELINE = new MarkdownPipelineBuilder()
+        .UseAdvancedExtensions()
+        .UseSoftlineBreakAsHardlineBreak()
+        .DisableHtml()
+        .Build();
+
     public static MudMarkdownProps DefaultConfig => new()
     {
         Heading =

--- a/app/MindWork AI Studio/wwwroot/changelog/v26.6.3.md
+++ b/app/MindWork AI Studio/wwwroot/changelog/v26.6.3.md
@@ -1,2 +1,3 @@
 # v26.6.3, build 243 (2026-06-xx xx:xx UTC)
 - Improved the chat experience by automatically focusing the message composer again when it becomes available. Thanks, Dominic Neuburg (`donework`), for the contribution.
+- Improved chat message formatting so line breaks in responses are preserved more closely, making structured text easier to read. Thanks, Dominic Neuburg (`donework`), for the contribution.


### PR DESCRIPTION
In the chat view, a single line break (Shift+Enter) was rendered as a space rather than a visible new line, only a blank line created a paragraph break. This is technically correct Markdown behavior, but counterintuitive in a chat context where users expect line breaks to be preserved.

A dedicated CHAT_MARKDOWN_PIPELINE was added in Markdown.cs alongside the existing SAFE_MARKDOWN_PIPELINE. Both share the same base configuration, but the chat pipeline additionally enables UseSoftlineBreakAsHardlineBreak(). ContentBlockComponent.razor now uses this pipeline for chat messages. All other Markdown rendering remains unchanged.

Test plan

- [x] Single line break (Shift+Enter) appears as a new line in the chat
- [x] Two line breaks produce a paragraph with spacing
- [x] AI responses with Markdown formatting still render correctly
- [x] Changelog and other non-chat Markdown content is unaffected