### PR TITLE
Security audit provider fallback

### DIFF
--- a/app/MindWork AI Studio/Agents/AssistantAudit/AssistantAuditAgent.cs
+++ b/app/MindWork AI Studio/Agents/AssistantAudit/AssistantAuditAgent.cs
@@ -117,10 +117,14 @@ public sealed class AssistantAuditAgent(ILogger<AssistantAuditAgent> logger, ILo
     /// <summary>
     /// Resolves and stores the provider configuration used for assistant plugin audits.
     /// </summary>
+    /// <param name="fallbackProvider">The provider to use when no provider is configured for the audit agent.</param>
     /// <returns>The configured provider, or <see cref="AIStudio.Settings.Provider.NONE"/> when no audit provider is configured.</returns>
-    public AIStudio.Settings.Provider ResolveProvider()
+    public AIStudio.Settings.Provider ResolveProvider(AIStudio.Settings.Provider? fallbackProvider = null)
     {
         var provider = this.SettingsManager.GetPreselectedProvider(Tools.Components.AGENT_ASSISTANT_PLUGIN_AUDIT, null, true);
+        if (provider == AIStudio.Settings.Provider.NONE && fallbackProvider is not null)
+            provider = fallbackProvider;
+
         this.ProviderSettings = provider;
         return provider;
     }
@@ -130,12 +134,13 @@ public sealed class AssistantAuditAgent(ILogger<AssistantAuditAgent> logger, ILo
     /// </summary>
     /// <param name="plugin">The assistant plugin to audit.</param>
     /// <param name="token">A cancellation token for prompt generation and the audit request.</param>
+    /// <param name="fallbackProvider">The provider to use when no provider is configured for the audit agent.</param>
     /// <returns>
     /// The parsed audit result, or an <c>UNKNOWN</c> result when no provider is configured or the model response cannot be used.
     /// </returns>
-    public async Task<AssistantAuditResult> AuditAsync(PluginAssistants plugin, CancellationToken token = default)
+    public async Task<AssistantAuditResult> AuditAsync(PluginAssistants plugin, CancellationToken token = default, AIStudio.Settings.Provider? fallbackProvider = null)
     {
-        var provider = this.ResolveProvider();
+        var provider = this.ResolveProvider(fallbackProvider);
         if (provider == AIStudio.Settings.Provider.NONE)
         {
             await MessageBus.INSTANCE.SendError(new (Icons.Material.Filled.SettingsSuggest, string.Format(TB("No provider is configured for the Security Audit Agent."))));

--- a/app/MindWork AI Studio/Assistants/Builder/AssistantBuilder.razor.cs
+++ b/app/MindWork AI Studio/Assistants/Builder/AssistantBuilder.razor.cs
@@ -570,7 +570,7 @@ public partial class AssistantBuilder : AssistantBaseCore<NoSettingsPanel>
         this.isAuditingPlugin = true;
         try
         {
-            this.pluginAudit = await this.AssistantPluginAuditService.RunAuditAsync(this.installedAssistantPlugin);
+            this.pluginAudit = await this.AssistantPluginAuditService.RunAuditAsync(this.installedAssistantPlugin, fallbackProvider: this.ProviderSettings);
             if (this.pluginAudit.Level is AssistantAuditLevel.UNKNOWN)
             {
                 this.FailInstallStep(BuilderInstallStep.SECURITY_CHECK, T("The security check could not determine a result."));

--- a/app/MindWork AI Studio/Tools/PluginSystem/Assistants/AssistantPluginAuditService.cs
+++ b/app/MindWork AI Studio/Tools/PluginSystem/Assistants/AssistantPluginAuditService.cs
@@ -7,9 +7,12 @@ namespace AIStudio.Tools.PluginSystem.Assistants;
 /// </summary>
 public sealed class AssistantPluginAuditService(AssistantAuditAgent auditAgent)
 {
-    public async Task<PluginAssistantAudit> RunAuditAsync(PluginAssistants plugin, CancellationToken token = default)
+    /// <summary>
+    /// Runs an assistant plugin audit, optionally falling back to the supplied provider when no audit provider is configured.
+    /// </summary>
+    public async Task<PluginAssistantAudit> RunAuditAsync(PluginAssistants plugin, CancellationToken token = default, Settings.Provider? fallbackProvider = null)
     {
-        var result = await auditAgent.AuditAsync(plugin, token);
+        var result = await auditAgent.AuditAsync(plugin, token, fallbackProvider);
         var provider = auditAgent.ProviderSettings;
         var promptPreview = await plugin.BuildAuditPromptPreviewAsync(token);
 

--- a/app/MindWork AI Studio/wwwroot/changelog/v26.7.3.md
+++ b/app/MindWork AI Studio/wwwroot/changelog/v26.7.3.md
@@ -9,6 +9,7 @@
 - Improved update guidance for Flatpak installations and added an enterprise option that lets organizations manage updates entirely through their IT department.
 - Improved secure API-key storage diagnostics on Linux. AI Studio now provides specific guidance when the default password collection is missing or locked, a password-manager prompt is dismissed, or no compatible Secret Service is available.
 - Improved the file dialogs to prevent opening multiple times when you click "Open" or "Save" multiple times in a row.
+- Improved the Assistant Builder security check so it can use the selected provider when no dedicated security audit agent provider is configured.
 - Fixed an issue that could leave AI Studio unresponsive after waking the computer from sleep. Yes, we know this was an annoying bug, and we apologize for the inconvenience.
 - Fixed connections to internal HTTPS services and enterprise configuration servers that use organization-provided root certificates on Linux.
 - Fixed enterprise configuration plugins from Windows-created ZIP files may not load correctly on Linux when the ZIP contained plugin files inside a folder.


### PR DESCRIPTION
We add a **fallback provider** for the assistant builder to the security audit agent, when user **did not preconfigure** a default provider for the audits