### PR TITLE
Assistant Builder: Settings Dialog

### DIFF
--- a/app/MindWork AI Studio/Assistants/Builder/AssistantBuilder.razor
+++ b/app/MindWork AI Studio/Assistants/Builder/AssistantBuilder.razor
@@ -1,7 +1,7 @@
 @attribute [Route(Routes.ASSISTANT_META_ASSISTANT)]
 @using AIStudio.Agents.AssistantAudit
 @using AIStudio.Tools.PluginSystem.Assistants.DataModel
-@inherits AssistantBaseCore<AIStudio.Dialogs.Settings.NoSettingsPanel>
+@inherits AssistantBaseCore<AIStudio.Dialogs.Settings.SettingsDialogAssistantBuilder>
 
 <PreviewBeta ApplyInnerScrollingFix="true"/>
 

--- a/app/MindWork AI Studio/Assistants/Builder/AssistantBuilder.razor.cs
+++ b/app/MindWork AI Studio/Assistants/Builder/AssistantBuilder.razor.cs
@@ -11,7 +11,7 @@ using DialogOptions = AIStudio.Dialogs.DialogOptions;
 
 namespace AIStudio.Assistants.Builder;
 
-public partial class AssistantBuilder : AssistantBaseCore<NoSettingsPanel>
+public partial class AssistantBuilder : AssistantBaseCore<SettingsDialogAssistantBuilder>
 {
     [Inject]
     private IDialogService DialogService { get; init; } = null!;
@@ -64,7 +64,6 @@ public partial class AssistantBuilder : AssistantBaseCore<NoSettingsPanel>
     protected override bool ShowProfileSelection => false;
     protected override bool ShowCopyResult => this.step is BuilderStep.DONE;
 
-    protected override bool HasSettingsPanel => false;
     protected override Func<string> Result2Copy => () => !string.IsNullOrWhiteSpace(this.generatedLuaAssistant)
         ? this.generatedLuaAssistant
         : this.generatedAssistantSpec;
@@ -209,9 +208,7 @@ public partial class AssistantBuilder : AssistantBaseCore<NoSettingsPanel>
         this.typicalInput = string.Empty;
         this.expectedOutput = string.Empty;
         this.selectedAssistantComponents = [];
-        this.selectedOutputLanguage = CommonLanguages.AS_IS;
-        this.customOutputLanguage = string.Empty;
-        this.allowGeneratedAssistantProfiles = true;
+        this.ApplyDefaultBuilderOptions();
         this.extraRules = string.Empty;
         this.exampleRequest = string.Empty;
         this.generatedAssistantSpec = string.Empty;
@@ -220,7 +217,27 @@ public partial class AssistantBuilder : AssistantBaseCore<NoSettingsPanel>
         this.ResetInstallFlow();
     }
 
-    protected override bool MightPreselectValues() => false;
+    protected override bool MightPreselectValues()
+    {
+        this.ApplyDefaultBuilderOptions();
+        return true;
+    }
+
+    private void ApplyDefaultBuilderOptions()
+    {
+        var defaults = this.SettingsManager.ConfigurationData.AssistantBuilder;
+        if (!defaults.PreselectOptions)
+        {
+            this.selectedOutputLanguage = CommonLanguages.AS_IS;
+            this.customOutputLanguage = string.Empty;
+            this.allowGeneratedAssistantProfiles = true;
+            return;
+        }
+
+        this.selectedOutputLanguage = defaults.PreselectedOutputLanguage;
+        this.customOutputLanguage = defaults.PreselectedOtherOutputLanguage;
+        this.allowGeneratedAssistantProfiles = true;
+    }
 
     /// <inheritdoc />
     protected override void CaptureCustomAssistantSessionState(AssistantSessionStateWriter state)

--- a/app/MindWork AI Studio/Assistants/I18N/allTexts.lua
+++ b/app/MindWork AI Studio/Assistants/I18N/allTexts.lua
@@ -6205,6 +6205,30 @@ UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBIAS::T6790
 -- When enabled, you can preselect options. This is might be useful when you prefer a specific language or LLM model.
 UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBIAS::T711745239"] = "When enabled, you can preselect options. This is might be useful when you prefer a specific language or LLM model."
 
+-- Preselect Assistant Builder options?
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T2127606148"] = "Preselect Assistant Builder options?"
+
+-- When disabled, the Assistant Builder uses the app provider and does not preselect an output language.
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T2235956198"] = "When disabled, the Assistant Builder uses the app provider and does not preselect an output language."
+
+-- Default custom output language
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T3360584376"] = "Default custom output language"
+
+-- Close
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T3448155331"] = "Close"
+
+-- Default output language
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T3652922567"] = "Default output language"
+
+-- Assistant: Assistant Builder defaults
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T3668274570"] = "Assistant: Assistant Builder defaults"
+
+-- Assistant Builder options are preselected
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T3962364100"] = "Assistant Builder options are preselected"
+
+-- No Assistant Builder options are preselected
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T4104323209"] = "No Assistant Builder options are preselected"
+
 -- Preselect one of your chat templates?
 UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGCHAT::T1402022556"] = "Preselect one of your chat templates?"
 

--- a/app/MindWork AI Studio/Dialogs/Settings/SettingsDialogAssistantBuilder.razor
+++ b/app/MindWork AI Studio/Dialogs/Settings/SettingsDialogAssistantBuilder.razor
@@ -1,0 +1,25 @@
+@using AIStudio.Settings
+@inherits SettingsDialogBase
+
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h6" Class="d-flex align-center">
+            <MudIcon Icon="@Icons.Material.Filled.AutoMode" Class="mr-2"/>
+            @T("Assistant: Assistant Builder defaults")
+        </MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudPaper Class="pa-3 mb-8 border-dashed border rounded-lg">
+            <ConfigurationOption OptionDescription="@T("Preselect Assistant Builder options?")" LabelOn="@T("Assistant Builder options are preselected")" LabelOff="@T("No Assistant Builder options are preselected")" State="@(() => this.SettingsManager.ConfigurationData.AssistantBuilder.PreselectOptions)" StateUpdate="@(value => this.SettingsManager.ConfigurationData.AssistantBuilder.PreselectOptions = value)" OptionHelp="@T("When disabled, the Assistant Builder uses the app provider and does not preselect an output language.")"/>
+            <ConfigurationSelect OptionDescription="@T("Default output language")" Disabled="@(() => !this.SettingsManager.ConfigurationData.AssistantBuilder.PreselectOptions)" SelectedValue="@(() => this.SettingsManager.ConfigurationData.AssistantBuilder.PreselectedOutputLanguage)" Data="@ConfigurationSelectDataFactory.GetCommonLanguagesOptionalData()" SelectionUpdate="@(value => this.SettingsManager.ConfigurationData.AssistantBuilder.PreselectedOutputLanguage = value)"/>
+            @if (this.SettingsManager.ConfigurationData.AssistantBuilder.PreselectedOutputLanguage is CommonLanguages.OTHER)
+            {
+                <ConfigurationText OptionDescription="@T("Default custom output language")" Disabled="@(() => !this.SettingsManager.ConfigurationData.AssistantBuilder.PreselectOptions)" Icon="@Icons.Material.Filled.Translate" Text="@(() => this.SettingsManager.ConfigurationData.AssistantBuilder.PreselectedOtherOutputLanguage)" TextUpdate="@(value => this.SettingsManager.ConfigurationData.AssistantBuilder.PreselectedOtherOutputLanguage = value)"/>
+            }
+            <ConfigurationProviderSelection Component="Components.META_ASSISTANT" Data="@this.AvailableLLMProviders" Disabled="@(() => !this.SettingsManager.ConfigurationData.AssistantBuilder.PreselectOptions)" SelectedValue="@(() => this.SettingsManager.ConfigurationData.AssistantBuilder.PreselectedProvider)" SelectionUpdate="@(value => this.SettingsManager.ConfigurationData.AssistantBuilder.PreselectedProvider = value)"/>
+        </MudPaper>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@this.Close" Variant="Variant.Filled">@T("Close")</MudButton>
+    </DialogActions>
+</MudDialog>

--- a/app/MindWork AI Studio/Dialogs/Settings/SettingsDialogAssistantBuilder.razor.cs
+++ b/app/MindWork AI Studio/Dialogs/Settings/SettingsDialogAssistantBuilder.razor.cs
@@ -1,0 +1,3 @@
+namespace AIStudio.Dialogs.Settings;
+
+public partial class SettingsDialogAssistantBuilder : SettingsDialogBase;

--- a/app/MindWork AI Studio/Pages/Assistants.razor
+++ b/app/MindWork AI Studio/Pages/Assistants.razor
@@ -19,7 +19,7 @@
             <AssistantBlock TSettings="SettingsDialogRewrite" Component="Components.REWRITE_ASSISTANT" Name="@T("Rewrite & Improve")" Description="@T("Rewrite and improve a given text for a chosen style.")" Icon="@Icons.Material.Filled.Edit" Link="@Routes.ASSISTANT_REWRITE"/>
             <AssistantBlock TSettings="SettingsDialogPromptOptimizer" Component="Components.PROMPT_OPTIMIZER_ASSISTANT" Name="@T("Prompt Optimizer")" Description="@T("Optimize your prompt using a structured guideline.")" Icon="@Icons.Material.Filled.AutoFixHigh" Link="@Routes.ASSISTANT_PROMPT_OPTIMIZER"/>
             <AssistantBlock TSettings="SettingsDialogSynonyms" Component="Components.SYNONYMS_ASSISTANT" Name="@T("Synonyms")" Description="@T("Find synonyms for a given word or phrase.")" Icon="@Icons.Material.Filled.Spellcheck" Link="@Routes.ASSISTANT_SYNONYMS"/>
-            <AssistantBlock TSettings="NoSettingsPanel" Component="Components.META_ASSISTANT" RequiredPreviewFeature="PreviewFeatures.PRE_META_ASSISTANT_V1" Name="@T("Assistant Builder")" Description="@T("Generate your own assistants.")" Icon="@Icons.Material.Filled.AutoMode" Link="@Routes.ASSISTANT_META_ASSISTANT"/>
+            <AssistantBlock TSettings="SettingsDialogAssistantBuilder" Component="Components.META_ASSISTANT" RequiredPreviewFeature="PreviewFeatures.PRE_META_ASSISTANT_V1" Name="@T("Assistant Builder")" Description="@T("Generate your own assistants.")" Icon="@Icons.Material.Filled.AutoMode" Link="@Routes.ASSISTANT_META_ASSISTANT"/>
         </AssistantCategoryBlock>
 
         @if (this.AssistantPlugins.Count > 0)

--- a/app/MindWork AI Studio/Plugins/languages/de-de-43065dbc-78d0-45b7-92be-f14c2926e2dc/plugin.lua
+++ b/app/MindWork AI Studio/Plugins/languages/de-de-43065dbc-78d0-45b7-92be-f14c2926e2dc/plugin.lua
@@ -6207,6 +6207,30 @@ UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBIAS::T6790
 -- When enabled, you can preselect options. This is might be useful when you prefer a specific language or LLM model.
 UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBIAS::T711745239"] = "Wenn diese Option aktiviert ist, können Sie Voreinstellungen vornehmen. Das kann nützlich sein, wenn Sie eine bestimmte Sprache oder ein bestimmtes LLM-Modell bevorzugen."
 
+-- Preselect Assistant Builder options?
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T2127606148"] = "Optionen für den Assistenten-Builder vorauswählen?"
+
+-- When disabled, the Assistant Builder uses the app provider and does not preselect an output language.
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T2235956198"] = "Wenn diese Option deaktiviert ist, verwendet der Assistenten-Builder den App-Anbieter und wählt keine Ausgabesprache vorab aus."
+
+-- Default custom output language
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T3360584376"] = "Standardmäßige benutzerdefinierte Ausgabesprache"
+
+-- Close
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T3448155331"] = "Schließen"
+
+-- Default output language
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T3652922567"] = "Standardsprache für Ausgaben"
+
+-- Assistant: Assistant Builder defaults
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T3668274570"] = "Assistent: Standardwerte für den Assistenten-Builder"
+
+-- Assistant Builder options are preselected
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T3962364100"] = "Optionen für den Assistenten-Builder sind vorausgewählt"
+
+-- No Assistant Builder options are preselected
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T4104323209"] = "Keine Optionen für den Assistenten-Builder sind vorausgewählt"
+
 -- Preselect one of your chat templates?
 UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGCHAT::T1402022556"] = "Eine ihrer Chat-Vorlagen vorab auswählen?"
 

--- a/app/MindWork AI Studio/Plugins/languages/en-us-97dfb1ba-50c4-4440-8dfa-6575daf543c8/plugin.lua
+++ b/app/MindWork AI Studio/Plugins/languages/en-us-97dfb1ba-50c4-4440-8dfa-6575daf543c8/plugin.lua
@@ -6207,6 +6207,30 @@ UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBIAS::T6790
 -- When enabled, you can preselect options. This is might be useful when you prefer a specific language or LLM model.
 UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBIAS::T711745239"] = "When enabled, you can preselect options. This is might be useful when you prefer a specific language or LLM model."
 
+-- Preselect Assistant Builder options?
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T2127606148"] = "Preselect Assistant Builder options?"
+
+-- When disabled, the Assistant Builder uses the app provider and does not preselect an output language.
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T2235956198"] = "When disabled, the Assistant Builder uses the app provider and does not preselect an output language."
+
+-- Default custom output language
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T3360584376"] = "Default custom output language"
+
+-- Close
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T3448155331"] = "Close"
+
+-- Default output language
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T3652922567"] = "Default output language"
+
+-- Assistant: Assistant Builder defaults
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T3668274570"] = "Assistant: Assistant Builder defaults"
+
+-- Assistant Builder options are preselected
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T3962364100"] = "Assistant Builder options are preselected"
+
+-- No Assistant Builder options are preselected
+UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGASSISTANTBUILDER::T4104323209"] = "No Assistant Builder options are preselected"
+
 -- Preselect one of your chat templates?
 UI_TEXT_CONTENT["AISTUDIO::DIALOGS::SETTINGS::SETTINGSDIALOGCHAT::T1402022556"] = "Preselect one of your chat templates?"
 

--- a/app/MindWork AI Studio/Settings/DataModel/Data.cs
+++ b/app/MindWork AI Studio/Settings/DataModel/Data.cs
@@ -160,6 +160,8 @@ public sealed class Data
     
     public DataSlideBuilder SlideBuilder { get; init; } = new();
 
+    public DataAssistantBuilder AssistantBuilder { get; init; } = new();
+
     /// <summary>
     /// Gets the managed Visual Briefing Assistant defaults.
     /// </summary>

--- a/app/MindWork AI Studio/Settings/DataModel/DataAssistantBuilder.cs
+++ b/app/MindWork AI Studio/Settings/DataModel/DataAssistantBuilder.cs
@@ -1,0 +1,28 @@
+namespace AIStudio.Settings.DataModel;
+
+/// <summary>
+/// Stores the default options for the Assistant Builder.
+/// </summary>
+public sealed class DataAssistantBuilder
+{
+    /// <summary>
+    /// Gets or sets whether Assistant Builder defaults are preselected.
+    /// </summary>
+    public bool PreselectOptions { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the provider used by default. An empty value uses the app default.
+    /// </summary>
+    public string PreselectedProvider { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the default output language for generated assistants.
+    /// </summary>
+    public CommonLanguages PreselectedOutputLanguage { get; set; } = CommonLanguages.AS_IS;
+
+    /// <summary>
+    /// Gets or sets the default custom output language.
+    /// </summary>
+    public string PreselectedOtherOutputLanguage { get; set; } = string.Empty;
+
+}

--- a/app/MindWork AI Studio/Tools/ComponentsExtensions.cs
+++ b/app/MindWork AI Studio/Tools/ComponentsExtensions.cs
@@ -180,6 +180,7 @@ public static class ComponentsExtensions
             Components.ERI_ASSISTANT => settingsManager.ConfigurationData.ERI.PreselectOptions ? settingsManager.ConfigurationData.Providers.FirstOrDefault(x => x.Id == settingsManager.ConfigurationData.ERI.PreselectedProvider) : null,
             Components.I18N_ASSISTANT => settingsManager.ConfigurationData.I18N.PreselectOptions ? settingsManager.ConfigurationData.Providers.FirstOrDefault(x => x.Id == settingsManager.ConfigurationData.I18N.PreselectedProvider) : null,
             Components.SLIDE_BUILDER_ASSISTANT => settingsManager.ConfigurationData.SlideBuilder.PreselectOptions ? settingsManager.ConfigurationData.Providers.FirstOrDefault(x => x.Id == settingsManager.ConfigurationData.SlideBuilder.PreselectedProvider) : null,
+            Components.META_ASSISTANT => settingsManager.ConfigurationData.AssistantBuilder.PreselectOptions ? settingsManager.ConfigurationData.Providers.FirstOrDefault(x => x.Id == settingsManager.ConfigurationData.AssistantBuilder.PreselectedProvider) : null,
             Components.VISUAL_BRIEFING_ASSISTANT => settingsManager.ConfigurationData.Providers.FirstOrDefault(x => x.Id == settingsManager.ConfigurationData.VisualBriefing.PreselectedProvider),
             
             // The Document Analysis Assistant does not have a preselected provider at the component level.


### PR DESCRIPTION
added a simple **settings dialog** for the **assistant builder** to set the default provider and the default plugin output language.

closes [277](https://gitlab.dlr.de/einstein/tasks/-/work_items/277)