### PR TITLE
Fix validation for empty prompts with attachments

### DIFF
--- a/app/MindWork AI Studio/Assistants/I18N/allTexts.lua
+++ b/app/MindWork AI Studio/Assistants/I18N/allTexts.lua
@@ -3394,6 +3394,9 @@ UI_TEXT_CONTENT["AISTUDIO::COMPONENTS::CHATCOMPONENT::T1516264254"] = "Save chat
 -- The media file could not be transcribed.
 UI_TEXT_CONTENT["AISTUDIO::COMPONENTS::CHATCOMPONENT::T1543974632"] = "The media file could not be transcribed."
 
+-- The attachment has not been sent. Please enter a prompt in the chat window
+UI_TEXT_CONTENT["AISTUDIO::COMPONENTS::CHATCOMPONENT::T1585750793"] = "The attachment has not been sent. Please enter a prompt in the chat window"
+
 -- Type your input here...
 UI_TEXT_CONTENT["AISTUDIO::COMPONENTS::CHATCOMPONENT::T1849313532"] = "Type your input here..."
 

--- a/app/MindWork AI Studio/Components/ChatComponent.razor.cs
+++ b/app/MindWork AI Studio/Components/ChatComponent.razor.cs
@@ -763,18 +763,27 @@ public partial class ChatComponent : MSGComponentBase, IAsyncDisposable
         await this.SyncForegroundChatAsync();
         return this.ChatThread;
     }
-    
+
     private async Task SendMessage(bool reuseLastUserPrompt = false)
     {
+
+
         if (this.MediaTranscriptionService.IsBusy(this.CurrentMediaImportOwner))
             return;
 
         if (!this.IsProviderSelected)
             return;
-        
+        if (!reuseLastUserPrompt && string.IsNullOrWhiteSpace(this.ComposerState.UserInput)
+                                 && this.ComposerState.FileAttachments.Count > 0)
+        {
+            await this.MessageBus.SendWarning(new(
+                Icons.Material.Filled.VoiceChat,
+                this.T("The attachment has not been sent. Please enter a prompt in the chat window"))); 
+        return;
+        }
         if(!this.ChatThread.IsLLMProviderAllowed(this.Provider))
             return;
-
+        
         this.RefreshCurrentProfileAndChatTemplate();
 
         // Blur the focus away from the input field to be able to clear it:

--- a/app/MindWork AI Studio/Plugins/languages/de-de-43065dbc-78d0-45b7-92be-f14c2926e2dc/plugin.lua
+++ b/app/MindWork AI Studio/Plugins/languages/de-de-43065dbc-78d0-45b7-92be-f14c2926e2dc/plugin.lua
@@ -3351,6 +3351,9 @@ UI_TEXT_CONTENT["AISTUDIO::COMPONENTS::ATTACHDOCUMENTS::T2250917004"] = "Einige 
 -- Drag and drop files into the marked area or click here to attach documents:
 UI_TEXT_CONTENT["AISTUDIO::COMPONENTS::ATTACHDOCUMENTS::T230755331"] = "Ziehen Sie Dateien in den markierten Bereich oder klicken Sie hier, um Dokumente anzuhängen:"
 
+-- The attachment has not been sent. Please enter a prompt in the chat window
+UI_TEXT_CONTENT["AISTUDIO::COMPONENTS::CHATCOMPONENT::T1585750793"] = "Der Anhang wurde nicht verschickt. Bitte gib einen Prompt in das Chatfenster ein"
+
 -- The media transcription was canceled.
 UI_TEXT_CONTENT["AISTUDIO::COMPONENTS::ATTACHDOCUMENTS::T241403726"] = "Die Transkription des Mediums wurde abgebrochen."
 


### PR DESCRIPTION
added a check that prevents Users from sending an empty message with an attached file. 
Displays a warning instead. Also added a german localization.